### PR TITLE
Add zero velocity processing at the end

### DIFF
--- a/raspimouse_control/include/raspimouse_control/raspimouse_hardware.hpp
+++ b/raspimouse_control/include/raspimouse_control/raspimouse_hardware.hpp
@@ -25,7 +25,7 @@ class RaspberryPiMouseHW : public hardware_interface::RobotHW
 {
 public:
   RaspberryPiMouseHW(ros::NodeHandle nh, ros::NodeHandle pnh);
-  // ~RaspberryPiMouseHW();
+  ~RaspberryPiMouseHW();
   void read(ros::Duration d);
   void write();
 

--- a/raspimouse_control/src/raspimouse_hardware.cpp
+++ b/raspimouse_control/src/raspimouse_hardware.cpp
@@ -53,6 +53,30 @@ RaspberryPiMouseHW::RaspberryPiMouseHW(ros::NodeHandle nh, ros::NodeHandle pnh)
   ROS_INFO("wheel_radius: %f", wheel_radius_);
 }
 
+RaspberryPiMouseHW::~RaspberryPiMouseHW()
+{
+  std::ofstream ofs_left;
+  std::ofstream ofs_right;
+
+  ofs_left.open(left_motor_device_file_);
+  if (not ofs_left.is_open())
+  {
+    ROS_ERROR("Cannot open %s", left_motor_device_file_.c_str());
+    return;
+  }
+  ofs_left << 0 << std::endl;
+  ofs_left.close();
+
+  ofs_right.open(right_motor_device_file_);
+  if (not ofs_right.is_open())
+  {
+    ROS_ERROR("Cannot open %s", right_motor_device_file_.c_str());
+    return;
+  }
+  ofs_right << 0 << std::endl;
+  ofs_right.close();
+}
+
 void RaspberryPiMouseHW::read(ros::Duration d)
 {
   pos[RIGHT] += vel[RIGHT] * d.nsec / 1000000000;


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
[Raspberry Pi Cat](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwjene-Vy6X6AhVnqVYBHYi1AkgQFnoECAwQAQ&url=https%3A%2F%2Frt-net.jp%2Fproducts%2Fraspberry-pi-cat%2F&usg=AOvVaw3-_KwfWi8lmbQwJpG0aNfW)を使用して、ナビゲーションをしている際にctl+c等でrosのノード(`raspimouse_hardware.cpp`)をキルし
再度ナビゲーションを立ち上げた際に勝手に走り出してしまう現象を確認しています。
1. rosのノードをkillした際にモータの出力(`/dev/rtmotoren0`)はオフ
2. デバイスファイル(`/dev/rtmotor_raw_[l0, r0]`)には今まで書き込まれていた速度指令値がそのまま残っている
3. モータの出力をオンにした際に今までの速度指令値が書き込まれているので走り出してしまう

そのため、rosのノード(`raspimouse_hardware.cpp`)をキルした際にデバイスファイル(`/dev/rtmotor_raw_[l0, r0]`)に速度0の速度指令値を書き込むような処理を追加しました。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->


# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
* 動作確認の手順(以下の手順で複数回確認)
1. 修正前のプログラムでナビゲーションを実行、速度指令値が出力され機体が動いている途中にctl+c等で
rosのノードをすべて落とす
2. 再度ナビゲーションを実行し、機体が勝手に走り出すことを確認
3. 修正後のプログラムでナビゲーションを実行、速度指令値が出力され機体が動いている途中にctl+c等で
rosのノードをすべて落とす
4. 再度ナビゲーションを実行し、機体が勝手に走り出さないことを確認


# Any other comments?
<!-- その他コメントはありますか？ -->
* [Raspberry Pi Mouse](https://rt-net.jp/products/raspberrypimousev3/?lang=ja)での動作確認は行っていません。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
